### PR TITLE
UI hotfixes

### DIFF
--- a/components/event-card.tsx
+++ b/components/event-card.tsx
@@ -66,7 +66,9 @@ export default function EventCard({ e, openModal }: Props) {
               eventColors["border"][e.eventType]
             } px-5 py-2`}
           >
-            <p className="text-lg font-medium xl:text-xl">{e.title}</p>
+            <p className="overflow-x-auto whitespace-nowrap text-lg font-medium xl:text-xl">
+              {e.title}
+            </p>
             {sameDay(e.date, e.dateEnd) && (
               <div className="flex items-center gap-2">
                 <BiTimeFive size={17.5} />{" "}

--- a/components/event-card.tsx
+++ b/components/event-card.tsx
@@ -5,6 +5,7 @@ import { EventInCMS } from "../types/event-in-cms";
 import FormattedDate from "./formatted-date";
 import FormattedTime from "./formatted-time";
 import { eventColors } from "../lib/eventColors";
+import shorten from "../lib/shorten";
 
 interface Props {
   e: EventInCMS;
@@ -66,9 +67,7 @@ export default function EventCard({ e, openModal }: Props) {
               eventColors["border"][e.eventType]
             } px-5 py-2`}
           >
-            <p className="overflow-x-auto whitespace-nowrap text-lg font-medium xl:text-xl">
-              {e.title}
-            </p>
+            <p className="text-lg font-medium xl:text-xl">{shorten(e.title)}</p>
             {sameDay(e.date, e.dateEnd) && (
               <div className="flex items-center gap-2">
                 <BiTimeFive size={17.5} />{" "}

--- a/components/event-showcase.tsx
+++ b/components/event-showcase.tsx
@@ -15,8 +15,8 @@ interface Props {
 
 export default function EventShowcase({ event }: Props) {
   return (
-    <>
-      <div className="img-frame h-80 md:rounded-3xl">
+    <div className="max-h-[40rem]">
+      <div className="img-frame h-60 sm:h-80 md:rounded-3xl">
         <Image
           src={event.images[0]}
           alt="Event image"
@@ -27,7 +27,7 @@ export default function EventShowcase({ event }: Props) {
       <div
         className={`flex border-t-2 border-solid ${
           eventColors["border"][event.eventType]
-        } px-7 py-5`}
+        } flex h-fit max-h-80 flex-col gap-3 px-7 py-5 md:flex-row md:items-center`}
       >
         <div className="flex min-w-[40%] flex-col justify-center">
           <div className="mb-4 flex flex-col items-start gap-3">
@@ -71,19 +71,14 @@ export default function EventShowcase({ event }: Props) {
           </div>
         </div>
         {event.body && (
-          <>
+          <div className="max-h-60 overflow-auto">
             <div
-              className={`mx-7 w-1 rounded-full border border-solid ${
-                eventColors["separator"][event.eventType]
-              }`}
-            />
-            <div
-              className={`${markdownStyle.markdown}`}
+              className={`${markdownStyle.markdown} overflow-auto`}
               dangerouslySetInnerHTML={{ __html: event.body || "" }}
             />
-          </>
+          </div>
         )}
       </div>
-    </>
+    </div>
   );
 }

--- a/components/event-showcase.tsx
+++ b/components/event-showcase.tsx
@@ -29,8 +29,8 @@ export default function EventShowcase({ event }: Props) {
           eventColors["border"][event.eventType]
         } px-7 py-5`}
       >
-        <div className="flex flex-col justify-center">
-          <div className="mb-1 flex items-center gap-4">
+        <div className="flex min-w-[40%] flex-col justify-center">
+          <div className="mb-4 flex flex-col items-start gap-3">
             <h1 className="text-2xl">{event.title}</h1>
             <div
               className={`rounded-full px-2.5 py-0.5 text-sm font-medium text-white ${
@@ -73,7 +73,7 @@ export default function EventShowcase({ event }: Props) {
         {event.body && (
           <>
             <div
-              className={`mx-7 w-1 rounded-full ${
+              className={`mx-7 w-1 rounded-full border border-solid ${
                 eventColors["separator"][event.eventType]
               }`}
             />

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -5,7 +5,7 @@ import Sitemap from "./sitemap";
 export default function Footer() {
   return (
     <footer className="flex flex-col gap-y-3 py-12 text-center">
-      <div className="flex flex-col justify-center gap-16 lg:flex-row lg:gap-20 xl:gap-28">
+      <div className="flex flex-col justify-center gap-16 xl:flex-row xl:gap-28">
         <Socials />
         <Sitemap />
       </div>

--- a/components/human-resources-team.tsx
+++ b/components/human-resources-team.tsx
@@ -20,7 +20,7 @@ export default function HRTeam({ allHRData }: Props) {
           </AnimatedEm>
         </h2>
         <p className="mt-4">
-          The Human Resources Division is in charge of the well being of the
+          The Human Resources Department is in charge of the well being of the
           members within the organization as well as the recruitment of aspiring
           members that are fit for the organization. This division fosters the
           relationships between members and ensures that all of the people

--- a/components/human-resources-team.tsx
+++ b/components/human-resources-team.tsx
@@ -1,0 +1,40 @@
+import AnimatedEm from "./animated-em";
+import ParallaxObject from "./parallax-object";
+import extractPortraits from "../lib/extractPortraits";
+import { MemberInCMS } from "../types/member-in-cms";
+
+interface Props {
+  allHRData: MemberInCMS[];
+}
+
+export default function HRTeam({ allHRData }: Props) {
+  return (
+    <section
+      id="communications"
+      className="md:mx-auto md:max-w-5xl lg:flex lg:items-center lg:gap-12"
+    >
+      <div className="max-w-sm px-10 lg:order-2 xl:max-w-md">
+        <h2>
+          <AnimatedEm emClassName="bg-blue-400/50 bottom-0 left-4">
+            Human Resources
+          </AnimatedEm>
+        </h2>
+        <p className="mt-4">
+          The Human Resources Division is in charge of the well being of the
+          members within the organization as well as the recruitment of aspiring
+          members that are fit for the organization. This division fosters the
+          relationships between members and ensures that all of the people
+          within the organization can perform at their best.
+        </p>
+      </div>
+      <div className="relative mx-auto mt-8 flex w-fit max-w-5xl flex-wrap justify-center gap-8 lg:mt-0">
+        <ParallaxObject
+          className="absolute -left-2 h-10 w-10 rounded-full bg-blue-400/50"
+          y={[-100, 200]}
+          end="bottom+=160 top"
+        />
+        {extractPortraits(allHRData)}
+      </div>
+    </section>
+  );
+}

--- a/components/link-group.tsx
+++ b/components/link-group.tsx
@@ -15,7 +15,7 @@ export default function LinkGroup({ head, links }: Props) {
     </Link>
   ));
   return (
-    <div className="text-left">
+    <div className="w-28 text-left">
       <Link href={`${head.href}`}>
         <p className="block cursor-pointer py-2.5 font-bold hover:underline">
           {head.text}

--- a/components/link-group.tsx
+++ b/components/link-group.tsx
@@ -17,9 +17,13 @@ export default function LinkGroup({ head, links }: Props) {
   return (
     <div className="w-28 text-left">
       <Link href={`${head.href}`}>
-        <p className="block cursor-pointer py-2.5 font-bold hover:underline">
-          {head.text}
-        </p>
+        {head.text ? (
+          <p className="block cursor-pointer py-2.5 font-bold hover:underline">
+            {head.text}
+          </p>
+        ) : (
+          <p className="block cursor-default py-2.5 font-bold">&nbsp;</p>
+        )}
       </Link>
       {linksJSX}
     </div>

--- a/components/mission.tsx
+++ b/components/mission.tsx
@@ -7,7 +7,7 @@ export default function Mission() {
       <p className="mt-2 mb-10 text-base md:text-lg">
         We, as an organization, aim to
       </p>
-      <div className="flex flex-col items-center gap-10 md:flex-row md:justify-center xl:gap-20">
+      <div className="flex flex-col items-center gap-5 md:flex-row md:justify-center xl:gap-20">
         {[
           {
             title: "Empower",

--- a/components/offset-grid.tsx
+++ b/components/offset-grid.tsx
@@ -19,7 +19,7 @@ export default function OffsetGrid({ elements }: Props) {
         return (
           <div
             key={index}
-            className="div-style1 relative flex w-96 flex-col justify-center overflow-hidden px-9 py-6 md:w-80 md:px-12 md:py-8 md:even:top-1/2 lg:w-96"
+            className="div-style1 relative flex w-full flex-col justify-center overflow-hidden px-9 py-6 sm:w-96 md:w-80 md:px-12 md:py-8 md:even:top-1/2 lg:w-96"
           >
             <div className="mb-2 gap-5 text-xl font-semibold md:mb-4 md:text-2xl">
               <AnimatedEm emClassName={`right-4 bottom-0 ${bgColor}`}>

--- a/components/portrait.tsx
+++ b/components/portrait.tsx
@@ -32,7 +32,7 @@ export default function Portrait({
 }: Props) {
   return (
     <div
-      className={`img-frame group relative flex h-52 w-40 flex-col justify-end overflow-hidden rounded-3xl text-sm shadow-2xl md:h-60 md:w-48 ${className}`}
+      className={`img-frame group relative flex h-44 w-32 flex-col justify-end overflow-hidden rounded-3xl text-sm shadow-2xl sm:h-52 sm:w-40 md:h-60 md:w-48 ${className}`}
     >
       <Image
         src={src}

--- a/components/portrait.tsx
+++ b/components/portrait.tsx
@@ -32,7 +32,7 @@ export default function Portrait({
 }: Props) {
   return (
     <div
-      className={`img-frame group relative flex h-44 w-32 flex-col justify-end overflow-hidden rounded-3xl text-sm shadow-2xl sm:h-52 sm:w-40 md:h-60 md:w-48 ${className}`}
+      className={`img-frame group relative flex h-44 w-36 flex-col justify-end overflow-hidden rounded-3xl text-sm shadow-2xl sm:h-52 sm:w-40 md:h-60 md:w-48 ${className}`}
     >
       <Image
         src={src}

--- a/components/project-showcase.tsx
+++ b/components/project-showcase.tsx
@@ -13,7 +13,7 @@ export default function ProjectShowcase({
   resetSelectedProject,
 }: Props) {
   return (
-    <div className="div-style1 relative mx-auto mt-12 max-w-sm sm:max-w-lg md:max-w-2xl">
+    <div className="div-style1 relative mx-auto mt-12 max-w-[90%] max-w-sm sm:max-w-lg md:max-w-2xl">
       <button
         className="absolute top-5 right-5 z-10 h-12 w-12 rounded-full bg-black/60 transition-all hover:rotate-90"
         onClick={resetSelectedProject}

--- a/components/sitemap.tsx
+++ b/components/sitemap.tsx
@@ -21,6 +21,23 @@ export default function Sitemap() {
     },
     {
       head: {
+        text: "Events",
+        href: "events",
+        show: true,
+      },
+      links: [
+        {
+          text: "Featured",
+          href: "featured",
+        },
+        {
+          text: "All Events",
+          href: "all-events",
+        },
+      ],
+    },
+    {
+      head: {
         text: "Team",
         href: "team",
         show: true,
@@ -42,6 +59,15 @@ export default function Sitemap() {
           text: "Communications",
           href: "communications",
         },
+      ],
+    },
+    {
+      head: {
+        text: "",
+        href: "",
+        show: false,
+      },
+      links: [
         {
           text: "Finance and Externals",
           href: "finance-and-externals",
@@ -56,29 +82,12 @@ export default function Sitemap() {
         },
       ],
     },
-    {
-      head: {
-        text: "Events",
-        href: "events",
-        show: true,
-      },
-      links: [
-        {
-          text: "Featured",
-          href: "featured",
-        },
-        {
-          text: "All Events",
-          href: "all-events",
-        },
-      ],
-    },
   ];
   const sitemapJSX = sections.map(({ head, links }, index) => (
     <LinkGroup key={index} head={head} links={links} />
   ));
   return (
-    <section className="mb-11 flex flex-wrap justify-center gap-10 px-10 text-base md:mb-0">
+    <section className="mb-11 grid grid-cols-2 justify-items-center gap-10 px-10 text-base md:mb-0 md:flex md:flex-wrap md:justify-center">
       {sitemapJSX}
     </section>
   );

--- a/components/sitemap.tsx
+++ b/components/sitemap.tsx
@@ -74,7 +74,7 @@ export default function Sitemap() {
     <LinkGroup key={index} head={head} links={links} />
   ));
   return (
-    <section className="mb-11 flex justify-center gap-x-14 text-base md:mb-0">
+    <section className="mb-11 flex flex-wrap justify-center gap-10 px-10 text-base md:mb-0">
       {sitemapJSX}
     </section>
   );

--- a/components/sitemap.tsx
+++ b/components/sitemap.tsx
@@ -47,6 +47,10 @@ export default function Sitemap() {
           href: "finance-and-externals",
         },
         {
+          text: "Human Resources",
+          href: "human-resources",
+        },
+        {
           text: "Web Development",
           href: "web-dev",
         },

--- a/components/vision.tsx
+++ b/components/vision.tsx
@@ -26,7 +26,7 @@ export default function Vision() {
             and innovation.
           </p>
           <AnimatedObject
-            className="img-frame div-style1 mx-auto h-96 w-96"
+            className="img-frame div-style1 mx-auto w-full sm:w-96"
             fromVars={{
               x: -100,
               opacity: 0,

--- a/lib/shorten.ts
+++ b/lib/shorten.ts
@@ -1,0 +1,8 @@
+export default function shorten(s: string): string {
+  const tokens = s.split(" ");
+  if (tokens.length <= 2) {
+    return s;
+  } else {
+    return tokens.slice(0, 2).join(" ") + "...";
+  }
+}

--- a/pages/team.tsx
+++ b/pages/team.tsx
@@ -8,6 +8,7 @@ import { getTeam } from "../lib/posts";
 import { useState } from "react";
 import Head from "next/head";
 import { isArrayOfMembersInCMS, MemberInCMS } from "../types/member-in-cms";
+import HRTeam from "../components/human-resources-team";
 
 interface Props {
   allMemberData: MemberInCMS[];
@@ -93,6 +94,9 @@ export default function Team({ allMemberData }: Props) {
         <FinExtTeam
           allExteFinData={getFilteredData(yearToShow, "Finance and Externals")}
         />
+        {yearToShow >= 2022 && (
+          <HRTeam allHRData={getFilteredData(yearToShow, "Human Resources")} />
+        )}
       </div>
       <WebDevTeam
         allWebDevData={getFilteredData(yearToShow, "Web Development")}
@@ -108,6 +112,7 @@ export async function getStaticProps() {
     "Operations",
     "Communications",
     "Finance and Externals",
+    "Human Resources",
     "Web Development",
   ];
 


### PR DESCRIPTION
(details on Discord, but included here in case I get zapped by a bot ~~I knew it...~~)

This PR addresses the following:

- some of the images and components were overflowing on mobile-sized screens; this is fixed now
- `team` part in sitemap is now 2-columns for space economy
- some event cards in `events/` looked so-not-pretty; I've alleviated this a bit, so hopefully at worst it only looks not-so-pretty now